### PR TITLE
Support WebURL on project snippets

### DIFF
--- a/project_snippets.go
+++ b/project_snippets.go
@@ -48,6 +48,7 @@ type Snippet struct {
 	} `json:"author"`
 	UpdatedAt *time.Time `json:"updated_at"`
 	CreatedAt *time.Time `json:"created_at"`
+	WebURL    string     `json:"web_url"`
 }
 
 func (s Snippet) String() string {


### PR DESCRIPTION
Project Snippets return `web_url` in the fields. Believe adding it to the struct here should allow us to pick it up.
Ref: https://docs.gitlab.com/ce/api/project_snippets.html